### PR TITLE
feat: add DELETE /bookmarks/:id endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const startTime = Date.now();
 let requestCount = 0;
 let totalResponseTime = 0;
 const bookmarks = [];
+let nextBookmarkId = 1;
 
 // Dependency checks for readiness probe
 const dependencyChecks = [
@@ -261,12 +262,26 @@ app.post('/bookmarks', asyncHandler((req, res) => {
   }
 
   const bookmark = {
+    id: nextBookmarkId++,
     url: url.trim(),
     title: title.trim(),
     created_at: new Date().toISOString()
   };
   bookmarks.push(bookmark);
   res.status(201).json(bookmark);
+}));
+
+app.delete('/bookmarks/:id', asyncHandler((req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    return res.status(400).json(createErrorResponse(400, 'Invalid bookmark ID', 'BAD_REQUEST'));
+  }
+  const index = bookmarks.findIndex(b => b.id === id);
+  if (index === -1) {
+    return res.status(404).json(createErrorResponse(404, 'Bookmark not found', 'NOT_FOUND'));
+  }
+  bookmarks.splice(index, 1);
+  res.status(204).end();
 }));
 
 app.get('/ready', asyncHandler(async (req, res) => {

--- a/test.js
+++ b/test.js
@@ -1539,6 +1539,23 @@ function deleteRequest(port, path) {
     req.on('error', reject);
     req.end();
   });
+  }
+
+function deleteRequestRaw(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: 'localhost',
+      port,
+      path,
+      method: 'DELETE'
+    }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ res, data }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
 }
 
 function testDeleteCacheEndpoint() {
@@ -1663,6 +1680,78 @@ function testBookmarksEndpointCreatedAt() {
   });
 }
 
+function testDeleteBookmarkSuccess() {
+  const app = require('./index');
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      try {
+        const port = server.address().port;
+        // Create a bookmark first
+        const { res: createRes, body: createBody } = await postJson(port, '/bookmarks', {
+          url: 'https://delete-me.com',
+          title: 'Delete Me'
+        });
+        assert.strictEqual(createRes.statusCode, 201);
+        assert.strictEqual(typeof createBody.id, 'number', 'bookmark must have numeric id');
+        // Delete it
+        const { res: delRes, data } = await deleteRequestRaw(port, `/bookmarks/${createBody.id}`);
+        assert.strictEqual(delRes.statusCode, 204, 'must return 204 on successful delete');
+        assert.strictEqual(data, '', 'body must be empty on 204');
+        console.log('PASS: DELETE /bookmarks/:id success');
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+function testDeleteBookmarkNotFound() {
+  const app = require('./index');
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      try {
+        const port = server.address().port;
+        const { res, body } = await deleteRequest(port, '/bookmarks/99999');
+        assert.strictEqual(res.statusCode, 404, 'must return 404 for non-existent bookmark');
+        assert.strictEqual(body.error, 'Bookmark not found');
+        assert.strictEqual(body.status, 404);
+        assert.strictEqual(body.code, 'NOT_FOUND');
+        console.log('PASS: DELETE /bookmarks/:id not found');
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+function testDeleteBookmarkInvalidId() {
+  const app = require('./index');
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      try {
+        const port = server.address().port;
+        const { res, body } = await deleteRequest(port, '/bookmarks/abc');
+        assert.strictEqual(res.statusCode, 400, 'must return 400 for invalid ID');
+        assert.strictEqual(body.error, 'Invalid bookmark ID');
+        assert.strictEqual(body.status, 400);
+        assert.strictEqual(body.code, 'BAD_REQUEST');
+        console.log('PASS: DELETE /bookmarks/:id invalid ID');
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
 (async () => {
   try {
     testParseUserInput();
@@ -1720,6 +1809,9 @@ function testBookmarksEndpointCreatedAt() {
     await testDeleteCacheResetsMetrics();
     await testVersionInfoEndpoint();
     await testBookmarksEndpointCreatedAt();
+    await testDeleteBookmarkSuccess();
+    await testDeleteBookmarkNotFound();
+    await testDeleteBookmarkInvalidId();
     console.log('All tests passed');
   } catch(e) {
     console.error('FAIL:', e.message);


### PR DESCRIPTION
Implements DELETE /bookmarks/:id to delete bookmarks by ID.

- Returns 204 No Content on successful deletion
- Returns 404 if bookmark not found
- Returns 400 for invalid ID format
- Added id field to bookmark creation in POST /bookmarks
- Includes tests for success, not found, and invalid ID cases

Closes #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `DELETE /bookmarks/:id` to remove bookmarks by numeric ID with correct status codes. Adds an auto-incrementing `id` to `POST /bookmarks` so clients can reference and delete entries; aligns with Linear I-4025282.

- **New Features**
  - `DELETE /bookmarks/:id`: returns 204 on success, 404 if not found, 400 for invalid ID.
  - `POST /bookmarks` now returns a numeric `id` for each new bookmark.
  - Tests added for delete success, not found, and invalid ID cases.

<sup>Written for commit 8ba30b30bf24ca251a28619efc5f1341a966262c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

