### PR TITLE
fix: correct content-type header for GET /health endpoint (#28)

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,6 +178,7 @@ app.get('/health', asyncHandler((req, res) => {
   }
   const elapsedMs = Date.now() - startTime;
   const mem = process.memoryUsage();
+  res.setHeader('Content-Type', 'application/json');
   res.json({
     status: 'ok',
     startedAt: new Date(startTime).toISOString(),

--- a/test.js
+++ b/test.js
@@ -53,6 +53,7 @@ function testHealthEndpoint() {
           try {
             const body = JSON.parse(data);
             assert.strictEqual(res.statusCode, 200);
+            assert.ok(res.headers['content-type'].includes('application/json'), 'Content-Type must be application/json');
             assert.strictEqual(body.status, 'ok');
             // Uptime fields
             assert.strictEqual(typeof body.startedAt, 'string');
@@ -113,6 +114,36 @@ function testHealthMemoryUsage() {
             // sanity: heapUsed <= heapTotal <= rss (typical invariant)
             assert.ok(body.memory.heapUsed <= body.memory.heapTotal, 'heapUsed <= heapTotal');
             console.log('PASS: health memory usage');
+            resolve();
+          } catch (err) {
+            reject(err);
+          } finally {
+            server.close();
+          }
+        });
+      }).on('error', (err) => {
+        server.close();
+        reject(err);
+      });
+    });
+  });
+}
+
+function testHealthContentType() {
+  const app = require('./index');
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const port = server.address().port;
+      http.get(`http://localhost:${port}/health`, (res) => {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => {
+          try {
+            assert.strictEqual(res.statusCode, 200);
+            assert.ok(res.headers['content-type'], 'Content-Type header must be present');
+            assert.ok(res.headers['content-type'].includes('application/json'), 'Content-Type must be application/json, got: ' + res.headers['content-type']);
+            assert.ok(!res.headers['content-type'].includes('text/plain'), 'Content-Type must not be text/plain');
+            console.log('PASS: health content-type');
             resolve();
           } catch (err) {
             reject(err);
@@ -2091,6 +2122,7 @@ function testAuthRateLimitEnforced() {
     testRequestLoggerExport();
     await testHealthEndpoint();
     await testHealthMemoryUsage();
+    await testHealthContentType();
     testFormatUptime();
     await testVersionEndpoint();
     await testValidateEndpointSuccess();


### PR DESCRIPTION
Fixes #28

The /health endpoint was returning text/plain instead of application/json. This fix ensures the endpoint returns the correct Content-Type header for JSON responses.

Changes:
- Updated /health endpoint to return application/json content-type
- Added tests to verify correct Content-Type header

All tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Content-Type for GET /health to return JSON. Clients now receive application/json instead of text/plain, with tests to prevent regressions.

- **Bug Fixes**
  - Set Content-Type to application/json in the /health handler before sending the JSON body.
  - Added tests to assert the header is present and not text/plain.

<sup>Written for commit 0ef920e1839df8830b4a1236d3c36ce1e719a3df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

